### PR TITLE
Adding Middleware for response header, logging and panic recovery

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -40,7 +40,7 @@ func main() {
 	if err != nil {
 		errorLog.Fatal(err)
 	}
-	// Initialize a new instance of application containing the dependencies.”
+	// Initialize a new instance of application containing the dependencies.
 	app := &application{
 		errorLog:      errorLog,
 		infoLog:       infoLog,

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Middleware flow:
+// secureHeaders --> servemux --> application handler
+func secureHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-XSS-Protection", "1, mode=block")
+		w.Header().Set("X-Frame-Options", "deny")
+
+		//Any Code here gets executed during the way in
+		next.ServeHTTP(w, r)
+
+		//Any Code here gets executed during the way back up
+	})
+}
+
+func (app *application) logRequest(next http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		app.infoLog.Printf("%s - %s %s %s", r.RemoteAddr, r.Proto, r.Method, r.URL.RequestURI())
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (app *application) recoverPanic(next http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// recover() is a built in function to check if there is a panic
+		// this deferred function will always run when go unwinds the call stack
+		defer func() {
+			if err := recover(); err != nil {
+				//trigger to make Go’s HTTP server automatically close the current connection after a response has been sent.
+				w.Header().Set("Conection", "close")
+				app.serverError(w, fmt.Errorf("%s", err))
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -1,8 +1,14 @@
 package main
 
-import "net/http"
+import (
+	"net/http"
 
-func (app *application) routes() *http.ServeMux {
+	"github.com/justinas/alice"
+)
+
+func (app *application) routes() http.Handler {
+	standardMiddleware := alice.New(app.recoverPanic, app.logRequest, secureHeaders)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", app.home)
 	mux.HandleFunc("/snippet", app.showSnippet)
@@ -11,5 +17,6 @@ func (app *application) routes() *http.ServeMux {
 	fileServer := http.FileServer(http.Dir("./ui/static/"))
 	mux.Handle("/static/", http.StripPrefix("/static", fileServer))
 
-	return mux
+	// return app.recoverPanic(app.logRequest(secureHeaders(mux))) (before alice)
+	return standardMiddleware.Then(mux)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module bajal/snippetbox
 go 1.17
 
 require github.com/go-sql-driver/mysql v1.6.0
+
+require github.com/justinas/alice v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=


### PR DESCRIPTION
When you’re building a web application there’s probably some shared functionality that you want to use for many (or even all) HTTP requests. For example, you might want to log every request, compress every response, or check a cache before passing the request to your handlers.

A common way of organizing this shared functionality is to set it up as middleware. This is essentially some self-contained code which independently acts on a request before or after your normal application handlers.
